### PR TITLE
update the logic for converting PowerPoint to PDF for non-Windows systems

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ requests==2.28.2
 django-allauth==0.52.0
 Pillow==9.5.0
 PyMuPDF==1.22.1
-pywin32==306
+pywin32==306; platform_system == "Windows"
 python-decouple==3.8


### PR DESCRIPTION
Refactor `utils.py` to import `platform` and `subprocess`, and add conditional imports for `pythoncom`, `win32com.client`, and `win32com.client.gencache` based on the `is_windows` variable, as well as define functions `convert_powerpoint_to_pdf_libreoffice`, `is_libreoffice_installed`, and `install_libreoffice`, and update the logic for converting PowerPoint to PDF to use `convert_powerpoint_to_pdf_libreoffice` for non-Windows systems. Update `requirements.txt` to include `pywin32` only for Windows systems.